### PR TITLE
Merge functionality with IPI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.21
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/ppc64le-cloud/powervs-utils
 
-go 1.15
+go 1.21
+
+toolchain go1.21.4
+
+require k8s.io/apimachinery v0.29.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+k8s.io/apimachinery v0.29.1 h1:KY4/E6km/wLBguvCZv8cKTeOwwOBqFNjwJIdMkMbbRc=
+k8s.io/apimachinery v0.29.1/go.mod h1:6HVkd1FwxIagpYrHSwJlQqZI3G9LfYWRPAkUvLnXTKU=


### PR DESCRIPTION
The IPI installer has a file (pkg/types/powervs/powervs_regions.go) which contains similiar data and functions.  We should merge the two and then use this library in IPI.