### PR TITLE
PowerVS: Add an only IPI regions list

### DIFF
--- a/region.go
+++ b/region.go
@@ -52,7 +52,20 @@ type Region struct {
 }
 
 // Regions provides a mapping between Power VS and IBM Cloud VPC and IBM COS regions.
-var Regions = map[string]Region{
+var Regions = FullRegions
+
+// Switch the list of regions to all of the regions.
+func UseFullRegions () {
+	Regions = FullRegions
+}
+
+// Switch the list of regions to only the regions supported by the IPI installer.
+func UseIPIRegions () {
+	Regions = IPIRegions
+}
+
+// NOTE: If you update information here, make sure you also update IPIRegions.
+var FullRegions = map[string]Region{
 	"dal": {
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
@@ -140,6 +153,60 @@ var Regions = map[string]Region{
 		COSRegion:   "us-east",
 		Zones:       []string{"us-east"},
 		SysTypes:    []string{}, // Missing
+	},
+	"wdc": {
+		Description: "Washington DC, USA",
+		VPCRegion:   "us-east",
+		COSRegion:   "us-east",
+		Zones: []string{
+			"wdc06",
+			"wdc07",
+		},
+		SysTypes:    []string{"s922", "e980"},
+	},
+}
+
+// NOTE: If you update information here, make sure you also update FullRegions.
+var IPIRegions = map[string]Region{
+	"dal": {
+		Description: "Dallas, USA",
+		VPCRegion:   "us-south",
+		COSRegion:   "us-south",
+		Zones:       []string{
+			"dal10",
+			"dal12",
+		},
+		SysTypes:    []string{"s922", "e980"},
+	},
+	"eu-de": {
+		Description: "Frankfurt, Germany",
+		VPCRegion:   "eu-de",
+		COSRegion:   "eu-de",
+		Zones: []string{
+			"eu-de-1",
+			"eu-de-2",
+		},
+		SysTypes:    []string{"s922", "e980"},
+	},
+	"mad": {
+		Description: "Madrid, Spain",
+		VPCRegion:   "eu-es",
+		COSRegion:   "eu-de",		// @HACK - PowerVS says COS not supported in this region
+		Zones: []string{
+			"mad02",
+			"mad04",
+		},
+		SysTypes:    []string{"s1022"},
+	},
+	"sao": {
+		Description: "São Paulo, Brazil",
+		VPCRegion:   "br-sao",
+		COSRegion:   "br-sao",
+		Zones:       []string{
+			"sao01",
+			"sao04",
+		},
+		SysTypes:    []string{"s922", "e980"},
 	},
 	"wdc": {
 		Description: "Washington DC, USA",

--- a/region_test.go
+++ b/region_test.go
@@ -170,3 +170,56 @@ func TestVPCRegionForPowerVSRegion(t *testing.T) {
 		})
 	}
 }
+
+func TestIPIMatches(t *testing.T) {
+	type args struct {
+		region string
+	}
+	type test []struct {
+		name          string
+		args          args
+		wantVPCRegion string
+		wantCOSRegion string
+	}
+	var i = 0
+
+	UseFullRegions ()
+
+	tests := make(test, len(IPIRegions))
+	for key, _ := range IPIRegions {
+		tests[i].name = IPIRegions[key].Description
+		tests[i].args = args{key}
+		tests[i].wantVPCRegion = IPIRegions[key].VPCRegion
+		tests[i].wantCOSRegion = IPIRegions[key].COSRegion
+		i++
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vpcRegion, err := VPCRegionForPowerVSRegion(tt.args.region)
+			if err != nil {
+				t.Errorf("VPCRegionForPowerVSRegion() error = %v", err)
+			}
+			if vpcRegion != tt.wantVPCRegion {
+				t.Errorf("VPCRegionForPowerVSRegion() vpcRegion = %v, want %v", vpcRegion, tt.wantVPCRegion)
+			}
+			if !ValidateVPCRegion(tt.wantVPCRegion) {
+				t.Errorf("ValidateVPCRegion() fails!")
+			}
+			cosRegion, err := COSRegionForVPCRegion(tt.wantVPCRegion)
+			if err != nil {
+				t.Errorf("COSRegionForVPCRegion() error = %v", err)
+			}
+			if cosRegion != tt.wantCOSRegion {
+				t.Errorf("COSRegionForVPCRegion() cosRegion = %v, want %v", cosRegion, tt.wantCOSRegion)
+			}
+			cosRegion, err = COSRegionForPowerVSRegion(tt.args.region)
+			if err != nil {
+				t.Errorf("COSRegionForPowerVSRegion() error = %v", err)
+			}
+			if cosRegion != tt.wantCOSRegion {
+				t.Errorf("COSRegionForPowerVSRegion() cosRegion = %v, want %v", cosRegion, tt.wantCOSRegion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In order for the IPI installer to be able to use this module, it needs the ability to have the list of regions to only include supported regions.