### PR TITLE
Update new regions and available machine types

### DIFF
--- a/region.go
+++ b/region.go
@@ -67,6 +67,8 @@ var regions = map[string]Region{
 		COSRegion:   "",
 		Zones: map[string]SysTypes{
 			"che01": {"e980", "s922"},
+			"che02": {"s1022"},
+			"che03": {"s1022", "s1122"},
 		},
 		VPCZones: []string{},
 	},
@@ -75,9 +77,9 @@ var regions = map[string]Region{
 		VPCRegion:   "us-south",
 		COSRegion:   "us-south",
 		Zones: map[string]SysTypes{
-			"dal10": {"e1080", "e980", "s1022", "s922"},
-			"dal12": {"e1080", "e1050", "e980", "s1022", "s922"},
-			"dal14": {"e1050", "e1080", "s1122", "s1022"},
+			"dal10": {"e1080", "s1022", "e980", "s922"},
+			"dal12": {"s1122", "e1080", "e1050", "s1022", "e980", "s922"},
+			"dal14": {"s1122", "e1080", "e1050", "s1022"},
 		},
 		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
@@ -86,8 +88,8 @@ var regions = map[string]Region{
 		VPCRegion:   "eu-de",
 		COSRegion:   "eu-de",
 		Zones: map[string]SysTypes{
-			"eu-de-1": {"e1080", "e1050", "e980", "s1122", "s1022", "s922"},
-			"eu-de-2": {"e980", "s1022", "s922"},
+			"eu-de-1": {"s1122", "e1080", "e1050", "s1022", "e980", "s922"},
+			"eu-de-2": {"e1080", "e1050", "s1022", "e980", "s922"},
 		},
 		VPCZones: []string{"eu-de-1", "eu-de-2", "eu-de-3"},
 	},
@@ -96,8 +98,8 @@ var regions = map[string]Region{
 		VPCRegion:   "eu-gb",
 		COSRegion:   "eu-gb",
 		Zones: map[string]SysTypes{
-			"lon04": {"e980", "s922"},
-			"lon06": {"e980", "s922"},
+			"lon04": {"s1022", "e980", "s922"},
+			"lon06": {"s1022", "e980", "s922"},
 		},
 		VPCZones: []string{"eu-gb-1", "eu-gb-2", "eu-gb-3"},
 	},
@@ -106,8 +108,8 @@ var regions = map[string]Region{
 		VPCRegion:   "eu-es",
 		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
 		Zones: map[string]SysTypes{
-			"mad02": {"e1050", "e1080", "e980", "s1122", "s1022", "s922"},
-			"mad04": {"e1050", "e1080", "e980", "s1022"},
+			"mad02": {"s1122", "e1080", "e1050", "s1022", "e980", "s922"},
+			"mad04": {"e1080", "e1050", "s1022", "e980"},
 		},
 		VPCZones: []string{"eu-es-1", "eu-es-2", "eu-es-3"},
 	},
@@ -134,8 +136,9 @@ var regions = map[string]Region{
 		VPCRegion:   "br-sao",
 		COSRegion:   "br-sao",
 		Zones: map[string]SysTypes{
-			"sao01": {"e980", "s1022", "s922"},
-			"sao04": {"e1050", "e1080", "e980", "s1022", "s922"},
+			"sao01": {"e1050", "s1022", "e980", "s922"},
+			"sao04": {"s1022", "e980", "s922"},
+			"sao05": {"e1080", "e1050", "s1022"},
 		},
 		VPCZones: []string{"br-sao-1", "br-sao-2", "br-sao-3"},
 	},
@@ -144,8 +147,8 @@ var regions = map[string]Region{
 		VPCRegion:   "au-syd",
 		COSRegion:   "au-syd",
 		Zones: map[string]SysTypes{
-			"syd04": {"e980", "s922"},
-			"syd05": {"e980", "s922"},
+			"syd04": {"s1022", "e980", "s922"},
+			"syd05": {"s1022", "e980", "s922"},
 		},
 		VPCZones: []string{"au-syd-1", "au-syd-2", "au-syd-3"},
 	},
@@ -163,7 +166,7 @@ var regions = map[string]Region{
 		VPCRegion:   "ca-tor",
 		COSRegion:   "ca-tor",
 		Zones: map[string]SysTypes{
-			"tor01": {"e980", "s922"},
+			"tor01": {"s1022", "e980", "s922"},
 		},
 		VPCZones: []string{"ca-tor-1", "ca-tor-2", "ca-tor-3"},
 	}, // Keeping us-east and us-south zones as individual entries to easily map the respective VPC and COS regions by matching the prefix of the zone like in GetRegion()
@@ -181,7 +184,7 @@ var regions = map[string]Region{
 		VPCRegion:   "us-south",
 		COSRegion:   "us-south",
 		Zones: map[string]SysTypes{
-			"us-south": {"e980", "s1022", "s922"},
+			"us-south": {"s1022", "e980", "s922"},
 		},
 		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
@@ -190,8 +193,8 @@ var regions = map[string]Region{
 		VPCRegion:   "us-east",
 		COSRegion:   "us-east",
 		Zones: map[string]SysTypes{
-			"wdc06": {"e1050", "e1080", "e980", "s1122", "s1022", "s922"},
-			"wdc07": {"e1050", "e1080", "e980", "s1022", "s922"},
+			"wdc06": {"s1122", "e1080", "e1050", "s1022", "e980", "s922"},
+			"wdc07": {"e1080", "e1050", "s1022", "e980", "s922"},
 		},
 		VPCZones: []string{"us-east-1", "us-east-2", "us-east-3"},
 	},

--- a/region_test.go
+++ b/region_test.go
@@ -394,7 +394,7 @@ func TestAvailableSysTypes(t *testing.T) {
 			testcasename:  "Systypes available",
 			region:        "wdc",
 			zoneName:      "wdc07",
-			systypes:      []string{"e1050", "e1080", "e980", "s1022", "s922"},
+			systypes:      []string{"e1080", "e1050", "s1022", "e980", "s922"},
 			expectedError: nil,
 		},
 	}


### PR DESCRIPTION
Based on:
```
cloudshell:~$ ibmcloud pi datacenter ls --json | jq -r '.datacenters[] | "\(.location.region),\(.capabilitiesDetails.supportedSystems.general[])"' | awk -F, '{if($1 in m){m[$1]=m[$1]", \""$2"\""}else{m[$1]="\"" $2 "\""}} END{for(k in m) print "\""k"\": {" m[k] "}"}' | sort
"che01": {"e980", "s922"}
"che02": {"s1022"}
"che03": {"s1022", "s1122"}
"dal10": {"e1080", "s1022", "e980", "s922"}
"dal12": {"s1122", "e1080", "e1050", "s1022", "e980", "s922"}
"dal14": {"s1122", "e1080", "e1050", "s1022"}
"eu-de-1": {"s1122", "e1080", "e1050", "s1022", "e980", "s922"}
"eu-de-2": {"e1080", "e1050", "s1022", "e980", "s922"}
"lon04": {"s1022", "e980", "s922"}
"lon06": {"s1022", "e980", "s922"}
"mad02": {"s1122", "e1080", "e1050", "s1022", "e980", "s922"}
"mad04": {"e1080", "e1050", "s1022", "e980"}
"mon01": {"e980", "s922"}
"osa21": {"s1022", "e980", "s922"}
"sao01": {"e1050", "s1022", "e980", "s922"}
"sao04": {"s1022", "e980", "s922"}
"sao05": {"e1080", "e1050", "s1022"}
"syd04": {"s1022", "e980", "s922"}
"syd05": {"s1022", "e980", "s922"}
"tok04": {"s1022", "e980", "s922"}
"tor01": {"s1022", "e980", "s922"}
"us-east": {"e980", "s922"}
"us-south": {"s1022", "e980", "s922"}
"wdc06": {"s1122", "e1080", "e1050", "s1022", "e980", "s922"}
"wdc07": {"e1080", "e1050", "s1022", "e980", "s922"}
```