### PR TITLE
Use go1.25 and update workflows to latest versions

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,12 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v6
       with:
-        go-version: 1.21
+        go-version-file: 'go.mod'
+    - run: go version
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/ppc64le-cloud/powervs-utils
 
-go 1.21
-
-toolchain go1.21.4
+go 1.25.8


### PR DESCRIPTION
Bumps go to 1.25 and updates GH actions to latest available releases.